### PR TITLE
Input parser

### DIFF
--- a/Conways.Tests/InputParserTests.cs
+++ b/Conways.Tests/InputParserTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Xunit;
 namespace Conways.Tests
 {
   public class InputParserTests
@@ -8,17 +10,22 @@ namespace Conways.Tests
       var input = "0,0 3,3 5,5";
       var dimensions = (6, 6);
       var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
-      Assert.True(indexes.SetEquals(new HashSet<(int, int)>((0, 0), (3, 3), (5, 5))));
+      Assert.True(indexes.SetEquals(new HashSet<(int, int)>{(0, 0), (3, 3), (5, 5)}));
     }
-    [Fact]
-    public void CanHandleTyposAndIgnoresThem()
-    {
+    // [Fact]
+    // public void CanHandleTyposAndIgnoresThem()
+    // {
+    //   var input = "0dfjaklsjf 0,0 3,3 5,5";
+    //   var dimensions = (6, 6);
+    //   var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
+    //   Assert.True(indexes.SetEquals(new HashSet<(int, int)>((0, 0), (3, 3), (5, 5))));
 
-    }
-    [Fact]
-    public void WontParseDuplicatInputIndexes()
-    {
 
-    }
+    // }
+    // [Fact]
+    // public void WontParseDuplicatInputIndexes()
+    // {
+
+    // }
   }
 }

--- a/Conways.Tests/InputParserTests.cs
+++ b/Conways.Tests/InputParserTests.cs
@@ -12,20 +12,32 @@ namespace Conways.Tests
       var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
       Assert.True(indexes.SetEquals(new HashSet<(int, int)>{(0, 0), (3, 3), (5, 5)}));
     }
-    // [Fact]
-    // public void CanHandleTyposAndIgnoresThem()
-    // {
-    //   var input = "0dfjaklsjf 0,0 3,3 5,5";
-    //   var dimensions = (6, 6);
-    //   var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
-    //   Assert.True(indexes.SetEquals(new HashSet<(int, int)>((0, 0), (3, 3), (5, 5))));
 
+    [Fact]
+    public void CanHandleTyposAndIgnoresThem()
+    {
+      var input = "0dfjak,lsjf 0,0 ldkfjiii4388 44,43 3,3 5,5";
+      var dimensions = (6, 6);
+      var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
+      Assert.True(indexes.SetEquals(new HashSet<(int, int)>{(0, 0), (3, 3), (5, 5)}));
+    }
 
-    // }
-    // [Fact]
-    // public void WontParseDuplicatInputIndexes()
-    // {
+    [Fact]
+    public void WontParseDuplicatInputIndexes()
+    {
+      var input = "0,0 0,0 0,0 3,3 3,3 3,3 2,2 2,2 2,2 2,2 2,2";
+      var dimensions = (6, 6);
+      var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
+      Assert.Equal(3, indexes.Count);
+    }
 
-    // }
+    [Fact]
+    public void WillOnlyParseInRangeIndexes()
+    {
+      var input = "0,0 4,5 2,2 3,3 6,6";
+      var dimensions = (6, 6);
+      var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
+      Assert.True(indexes.SetEquals(new HashSet<(int, int)>{(0, 0), (4, 5), (2, 2), (3,3)}));
+    }
   }
 }

--- a/Conways.Tests/InputParserTests.cs
+++ b/Conways.Tests/InputParserTests.cs
@@ -1,0 +1,24 @@
+namespace Conways.Tests
+{
+  public class InputParserTests
+  {
+    [Fact]
+    public void CanParseValidInput()
+    {
+      var input = "0,0 3,3 5,5";
+      var dimensions = (6, 6);
+      var indexes = InputParser.ParseInputToValidIndexes(input, dimensions);
+      Assert.True(indexes.SetEquals(new HashSet<(int, int)>((0, 0), (3, 3), (5, 5))));
+    }
+    [Fact]
+    public void CanHandleTyposAndIgnoresThem()
+    {
+
+    }
+    [Fact]
+    public void WontParseDuplicatInputIndexes()
+    {
+
+    }
+  }
+}

--- a/Conways/ConsoleInput.cs
+++ b/Conways/ConsoleInput.cs
@@ -33,27 +33,16 @@ namespace Conways
 
     public static bool IsValidDimension(int value) => value <= 30 && value >= 3;
 
-    public ISet<(int, int)> GetStartingState((int rowCount, int colCount) dimensions)
+    public ISet<(int, int)> GetValidIndexes((int rowCount, int colCount) dimensions)
     {
       var indexList = new HashSet<(int, int)>();
       while (indexList.Count < 3)
       {
         var input = ReadInput("enter indexes to set alive eg 0,0 0,1 0,2");
-        var indexes = input.Split(" ");
-        foreach (string index in indexes)
-        {
-          if (index.Length >= 3)
-          {
-            var rowTryParse = int.TryParse(index[0].ToString(), out int row);
-            var colTryParse = int.TryParse(index[2].ToString(), out int column);
-            if (rowTryParse && colTryParse && row <= dimensions.rowCount - 1 && column <= dimensions.colCount - 1)
-            {
-              indexList.Add((row, column));
-            }
-          }
-        }
+        indexList = new HashSet<(int, int)>(InputParser.ParseInputToValidIndexes(input, dimensions));
       }
       return indexList;
     }
+
   }
 }

--- a/Conways/ConsoleInput.cs
+++ b/Conways/ConsoleInput.cs
@@ -43,6 +43,5 @@ namespace Conways
       }
       return indexList;
     }
-
   }
 }

--- a/Conways/InputParser.cs
+++ b/Conways/InputParser.cs
@@ -23,6 +23,5 @@ namespace Conways
       }
       return indexList;
     }
-
   }
 }

--- a/Conways/InputParser.cs
+++ b/Conways/InputParser.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Conways
+{
+  public static class InputParser
+  {
+    public static ISet<(int, int)> ParseInputToValidIndexes(string input, (int rowCount, int colCount) dimensions)
+    {
+      var indexList = new HashSet<(int, int)>();
+      var indexes = input.Split(" ");
+
+      foreach (string index in indexes)
+      {
+        if (index.Length >= 3)
+        {
+          var rowTryParse = int.TryParse(index[0].ToString(), out int row);
+          var colTryParse = int.TryParse(index[2].ToString(), out int column);
+          if (rowTryParse && colTryParse && row <= dimensions.rowCount - 1 && column <= dimensions.colCount - 1)
+          {
+            indexList.Add((row, column));
+          }
+        }
+      }
+      return indexList;
+    }
+
+  }
+}

--- a/Conways/Program.cs
+++ b/Conways/Program.cs
@@ -6,7 +6,7 @@
     {
       var userInput = new ConsoleInput();
       var dimensions = userInput.GetDimensions();
-      var indexes = userInput.GetStartingState(dimensions);
+      var indexes = userInput.GetValidIndexes(dimensions);
       var world = new World(dimensions.Item1, dimensions.Item2, indexes);
       var renderer = new ConsoleRenderer();
       Simulation.Run(renderer, world);


### PR DESCRIPTION
decided to abstract input parser from consoleinput. The parsing of a string isn't actually paritcularly console bound - people may have lists of indexes for patterns they want to load in or it's concievable a UI would have a string input option and not soley point and click. 

so the parsing is a good candidate for abstraction. More testable as a seperate static class too.

the getting pattern and part of validation (the length of input) stays becaues that is domain specific. 
Getting the dimensions is also specific - the while pattern is very 'console' and so are the rules concerning validation as they are informed by the size of the terminal buffer essentialy!